### PR TITLE
Update README.md file to correct command for starting mariadb service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ sudo systemctl enable firewalld
 ```
 sudo yum install -y mariadb-server
 sudo vi /etc/my.cnf
-sudo service mariadb start
+#sudo service mariadb start     --not working
+sudo systemctl start mariadb    --added this
 sudo systemctl enable mariadb
 ```
 


### PR DESCRIPTION
added changes with respect to starting mariadb service using systemctl in section 'Install MariaDB'

removed(commented): sudo service mariadb start
added: sudo systemctl start mariadb

error:
![Screenshot 2023-09-03 111444](https://github.com/kodekloudhub/learning-app-ecommerce/assets/26535858/c17e562e-2241-4d91-ae1a-c74f4b41192f)
